### PR TITLE
Add help command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,5 @@ python -m shell_emulator.main --vfs vfs.json --script start_script.txt
 
 - `ls`, `cd`, `exit`
 - `history`, `cal`, `head`
-- `touch`, `mkdir`
+- `touch`, `mkdir`, `help`
+

--- a/shell_emulator/commands.py
+++ b/shell_emulator/commands.py
@@ -89,6 +89,10 @@ class Commands:
         except Exception as e:
             raise CommandError(str(e))
 
+    def help(self, args: List[str]) -> str:
+        commands = sorted(list(COMMAND_MAP.keys()) + ['exit'])
+        return 'Available commands: ' + ', '.join(commands)
+
 COMMAND_MAP = {
     'ls': Commands.ls,
     'cd': Commands.cd,
@@ -97,4 +101,5 @@ COMMAND_MAP = {
     'head': Commands.head,
     'touch': Commands.touch,
     'mkdir': Commands.mkdir,
+    'help': Commands.help,
 }


### PR DESCRIPTION
## Summary
- Implement a `help` command to list available shell commands
- Document the new command in the README

## Testing
- `python -m py_compile shell_emulator/*.py`
- `python - <<'PY'
from shell_emulator.shell import Shell
from shell_emulator.vfs import VFS
v = VFS({'/': {}})
sh = Shell(v)
print(sh.execute_line('help'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b746134190832c9179eea6c6e1bb21